### PR TITLE
FIX: Rel. imports and change in map under 3.x

### DIFF
--- a/figurefirst/__init__.py
+++ b/figurefirst/__init__.py
@@ -1,4 +1,4 @@
-import svg_to_axes
-reload(svg_to_axes)
-import mpl_functions
-from svg_to_axes import FigureLayout
+from . import svg_to_axes
+#reload(svg_to_axes)
+from . import mpl_functions
+from .svg_to_axes import FigureLayout

--- a/figurefirst/mpl_functions.py
+++ b/figurefirst/mpl_functions.py
@@ -7,7 +7,7 @@ import os
 # Load some user parameters / defaults
 # By default figurefirst will load the figurefirst_user_parameters.py file from the figurefirst/figurefirst directory.
 # If you would like to set custom parameters, copy that defaults file to another location.
-# Then make the changes you like and set the environment variable 'figurefirst_user_parameters' to point to the new file. 
+# Then make the changes you like and set the environment variable 'figurefirst_user_parameters' to point to the new file.
 # It will be loaded instead.
 try:
     figurefirst_user_parameters = os.environ['figurefirst_user_parameters']
@@ -16,7 +16,7 @@ except:
     figurefirst_user_parameters = 'default'
 
 if figurefirst_user_parameters == 'default':
-    import figurefirst_user_parameters
+    from . import figurefirst_user_parameters
 else:
     import imp
     figurefirst_user_parameters = imp.load_source('figurefirst_user_parameters', figurefirst_user_parameters)
@@ -26,30 +26,30 @@ else:
 ###################################################################################################
 
 # NOTE: smart_bounds is disabled (commented out) in this function. It only works in matplotlib v >1.
-# to fix this issue, try manually setting your tick marks (see example below) 
+# to fix this issue, try manually setting your tick marks (see example below)
 def adjust_spines(ax,spines, spine_locations={}, smart_bounds=True, xticks=None, yticks=None, linewidth=1, spine_location_offset=None):
     if type(spines) is not list:
         spines = [spines]
-        
+
     # get ticks
     if xticks is None:
         xticks = ax.get_xticks()
     if yticks is None:
         yticks = ax.get_yticks()
-        
+
     spine_locations_dict = figurefirst_user_parameters.spine_locations
     for key in spine_locations.keys():
         spine_locations_dict[key] = spine_locations[key]
         if spine_location_offset is not None:
             spine_locations_dict[key] = spine_location_offset
-        
+
     if 'none' in spines:
         for loc, spine in ax.spines.iteritems():
             spine.set_color('none') # don't draw spine
         ax.yaxis.set_ticks([])
         ax.xaxis.set_ticks([])
         return
-    
+
     for loc, spine in ax.spines.iteritems():
         if loc in spines:
             spine.set_position(('outward',spine_locations_dict[loc])) # outward by x points
@@ -57,9 +57,9 @@ def adjust_spines(ax,spines, spine_locations={}, smart_bounds=True, xticks=None,
             spine.set_color('black')
         else:
             spine.set_color('none') # don't draw spine
-            
+
     # smart bounds, if possible
-    if int(matplotlib.__version__[0]) > 0 and smart_bounds: 
+    if int(matplotlib.__version__[0]) > 0 and smart_bounds:
         for loc, spine in ax.spines.items():
             if loc in ['left', 'right']:
                 ticks = yticks
@@ -82,24 +82,24 @@ def adjust_spines(ax,spines, spine_locations={}, smart_bounds=True, xticks=None,
         ax.xaxis.set_ticks_position('top')
     else:
         # no xaxis ticks
-        ax.xaxis.set_ticks([])    
-    
+        ax.xaxis.set_ticks([])
+
     if 'left' in spines or 'right' in spines:
         ax.set_yticks(yticks)
     if 'top' in spines or 'bottom' in spines:
         ax.set_xticks(xticks)
-    
+
     for line in ax.get_xticklines() + ax.get_yticklines():
         #line.set_markersize(6)
         line.set_markeredgewidth(linewidth)
 
-        
+
 def kill_spines(ax):
-    return adjust_spines(ax,'none', 
-                  spine_locations={}, 
-                  smart_bounds=True, 
-                  xticks=None, 
-                  yticks=None, 
+    return adjust_spines(ax,'none',
+                  spine_locations={},
+                  smart_bounds=True,
+                  xticks=None,
+                  yticks=None,
                   linewidth=1)
 
 def kill_labels(ax):


### PR DESCRIPTION
Added relitive imports and cast the map as a list to allow the index method to
work. Partial fix for python 3.x I have NOT checked 2.7 compatibility.
From Issue #20 