### PR TITLE
edits for stylistic consistency

### DIFF
--- a/figurefirst/mpl_fig_to_figurefirst_svg.py
+++ b/figurefirst/mpl_fig_to_figurefirst_svg.py
@@ -27,19 +27,16 @@ def get_empty_svg_document(tmp_filename='.fifi_tmp.svg'):
                     'id': "svg2",
                     'version': "1.1",
                     'inkscape:version': "0.91 r13725",
-    }
-   
+                   }
 
     for attribute, value in attributes.items():
         svg.setAttribute(attribute, value)
 
     doc.appendChild(svg)
-
     outfile = open(tmp_filename, 'w')
     doc.writexml(outfile, encoding='utf-8')
 
     return tmp_filename
-
 
 def set_figure_size(fig, layout):
     svg = layout.output_xml.getElementsByTagName('svg')[0]
@@ -49,11 +46,12 @@ def set_figure_size(fig, layout):
     svg.setAttribute('height', repar(height, 'in'))
     viewBox = "0 0 " + str(width*72) + " " + str(height*72)
     svg.setAttribute('viewBox', viewBox)
+    
     return layout
 
 def load_template_svg():
     tmp_filename = get_empty_svg_document()
-    return FigureLayout( tmp_filename )
+    return FigureLayout(tmp_filename)
 
 def create_rect_for_ax(layout, parent, ax, name):
     new_rect = layout.output_xml.createElement('rect')
@@ -64,28 +62,27 @@ def create_rect_for_ax(layout, parent, ax, name):
     width, height = ax.figure.get_size_inches()
 
     # set default attributes
-    attributes = {  u'x': unicode( width*tounit([bbox.x0,'in'],'px')),
-                    u'y': unicode( height*tounit([1-bbox.y0-bbox.height,'in'],'px')),
-                    u'width': unicode( width*tounit([bbox.width,'in'],'px')),
-                  	u'height': unicode( height*tounit([bbox.height,'in'],'px')),
+    attributes = {  u'x': unicode(width*tounit([bbox.x0,'in'],'px')),
+                    u'y': unicode(height*tounit([1-bbox.y0-bbox.height,'in'],'px')),
+                    u'width': unicode(width*tounit([bbox.width,'in'],'px')),
+                  	u'height': unicode(height*tounit([bbox.height,'in'],'px')),
                   }
+
     for attribute, value in attributes.items():
         new_rect.setAttribute(attribute, value)
 
     new_rect.appendChild(figurefirst_axis_tag)
-
     parent.appendChild(new_rect)
 
 def mpl_fig_to_figurefirst_svg(mpl_fig, output_filename, design_layer_name='mpl_design_layer', figurefirst_figure_name='mpl_output_layer'):
     '''
-    Given a maptplot lib figure (mpl_fig) with multiple axes, this function creates an SVG file
-    that conforms to the FigureFirst specs with rectangles drawn and tagged for each maptplotlib axis.
-    The axes are grouped together under a figurefirst:figure tag (name:mpl_output_layer), and the layout is saved to 
-
+    Given a matplotlib figure (mpl_fig) with multiple axes, this function creates an
+    svg file (output_filename) that conforms to the figurefirst specs with rectangles
+    drawn and tagged for each matplotlib axis. The axes are grouped together under a
+    figurefirst:figure tag (name:mpl_output_layer), and the layout is saved to svg. 
     '''
     layout = load_template_svg()
     layout = set_figure_size(mpl_fig, layout)
-
 
     layout.create_new_targetlayer(design_layer_name)
 
@@ -100,12 +97,10 @@ def mpl_fig_to_figurefirst_svg(mpl_fig, output_filename, design_layer_name='mpl_
 
     group.appendChild(figurefirst_figure_tag)
 
-
     for i, ax in enumerate(mpl_fig.axes):
         create_rect_for_ax(layout, group, ax, 'ax'+str(i))
 
     layout.write_svg(output_filename)
-
     layout = FigureLayout(output_filename, make_mplfigures=True)
 
     return layout
@@ -130,7 +125,6 @@ def add_mpl_fig_to_figurefirst_svg(fifi_svg_filename, mpl_fig, output_filename, 
        create_rect_for_ax(layout, group, ax, 'ax'+str(i))
 
     layout.write_svg(output_filename)
-
     layout = FigureLayout(output_filename, make_mplfigures=True)
 
     return layout


### PR DESCRIPTION
In docstring for mpl_fig_to_figurefirst_svg(), no output filepath was specified; should be 'output_filename' ?