### PR TITLE
Fix README rendering, lru_cache bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you use FigureFirst, please cite the above paper to help others find FigureFi
 ## Installation
 
 ```bash
-pip install git+git://github.com/FlyRanch/figurefirst.git
+pip install figurefirst
 ```
 
 ## Use with Inkscape

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
 numpy
-matplotlib
+matplotlib>=3.0
 dill
 pytest
-twine
+twine>=1.11.0
+setuptools>=38.6.0
+wheel>=0.31.0
 scipy
+backports.functools_lru_cache; python_version<'3.3'
 tox
+

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,12 @@
 import os
 from setuptools import setup, find_packages
 
-here = os.path.realpath(__file__)
-ext_dir = os.path.join(os.path.dirname(here), 'inkscape_extensions')
+here = os.path.dirname(os.path.realpath(__file__))
+
+with open(os.path.join(here, "README.md")) as f:
+    long_description = f.read()
+
+ext_dir = os.path.join(here, 'inkscape_extensions')
 
 ext_files = [
     os.path.join("inkscape_extensions", fname)
@@ -16,7 +20,12 @@ setup(
     author='Floris van Breugel, Theodore Lindsay, Peter Weir',
     author_email='floris@caltech.edu',
     packages=find_packages(exclude=("inkscape_extensions", "test")),
-    install_requires=["numpy", "matplotlib", "dill"],
+    install_requires=[
+        "numpy",
+        "matplotlib",
+        "dill",
+        "backports.functools_lru_cache; python_version<'3.3'"
+    ],
     include_package_data=True,
     license='BSD',
     entry_points={
@@ -27,6 +36,6 @@ setup(
     test_requires=["pytest", "scipy", "tox"],
     data_files=[("inkscape_extensions", ext_files)],
     description='Matplotlib plotting stuff',
-    long_description=open('README.md').read(),
+    long_description=long_description,
     long_description_content_type="text/markdown"
 )


### PR DESCRIPTION
- The README is only rendered properly on PyPI if uploaded with a modern version of setuptools/twine/wheel, so that is now specified in requirements
- README updated to reflect that it's now on PyPI :smile:
- Require backported lru_cache (see #44 )

Note that the backported LRU cache is not the only issue preventing figurefirst from working with py2.