### PR TITLE
Document layer-hiding behaviour and fix FigureLayout docstring

### DIFF
--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -35,7 +35,7 @@ Now if we want to plot data to any of these axes, we can direct our plotting com
 To construct a similar plot in figurefirst, we use Inkscape to create an svg layout document by drawing boxes where the five axes should lie, then tag these boxes with names, e.g., ax1, ax2, etc. To make the figure in Python, we then construct a :class:`~figurefirst.svg_to_axes.FigureLayout` object by passing the path to the layout document: ::
 
 	import figurefirst as fifi
-	layout = fifi.FigureLayout('/path/to/layout.svg')
+	layout = fifi.FigureLayout('/path/to/layout.svg', make_mplfigures=True)
 
 figurefirst will construct the matplotlib figure and store the axes by their tag name in the 'axes' attribute of the layout object. For example, to plot on ax1: ::
 
@@ -52,9 +52,17 @@ So how do you design a layout? The easiest approach is to use Inkscape and take 
 Merging matplotlib plots back into the layout
 ----------------------------------------------
 
-Simply being able to use svg as a specification for axis placement is a useful feature on it's own, but figurefirst allows you to take things one step further and direct the output of your plotting code back into the svg layout document. This means that any svg vector art that you include in your layout document can now be used as overlays and underlays to your matplotlib figures. To save our new plots we simply call ::
+Simply being able to use svg as a specification for axis placement is a useful feature on it's own, but figurefirst allows you to take things one step further and direct the output of your plotting code back into the svg layout document.
+This means that any svg vector art that you include in your layout document can now be used as overlays and underlays to your matplotlib figures.
+To save our new plots we simply call ::
 
 	layout.save('/path/to/output_file.svg')
 
-By default figurefirst will create a new svg layer to place all the new matplotlib artwork. Note that merging your newly plotted figures with the layout in this way also provides a mechanism for fast iterative development of your figures. If you save the plotted data back into the layout document (passing the original layout file as output_file), you can now make adjustments to the layout, add annotations, etc., now that you have a better idea of how the data lie within the figure. After making these changes, the plotting code can be re-run at any time to regenerate the plots without worrying about loosing these annotations.
+By default figurefirst will create a new svg layer to place all the new matplotlib artwork.
+Note that merging your newly plotted figures with the layout in this way also provides a mechanism for fast iterative development of your figures.
+If you save the plotted data back into the layout document (passing the original layout file as output_file), you can now make adjustments to the layout, add annotations, etc., now that you have a better idea of how the data lie within the figure.
+After making these changes, the plotting code can be re-run at any time to regenerate the plots without worrying about loosing these annotations.
 
+By default, figurefirst will assume the layer called ``"Layer 1"`` is your template layer, and hide it.
+To disable this, set ``hide_layers=[]`` in the constructor.
+By preference, put non-template elements of your element on another layer.

--- a/figurefirst/svg_to_axes.py
+++ b/figurefirst/svg_to_axes.py
@@ -767,8 +767,7 @@ class FigureLayout(object):
         if make_mplfigures:
             self.make_mplfigures()
 
-        for layer in hide_layers:
-            self.set_layer_visibility(layer, False)
+        self._hide_layers(*hide_layers)
 
     def __getattr__(self, attr):
         if attr == 'fig':
@@ -1245,19 +1244,22 @@ class FigureLayout(object):
             outfile.write(self.output_xml.toxml().encode('ascii', 'xmlcharrefreplace'))
             outfile.close()
 
-    def save(self,filename,hidelayers = [],targetlayer = None,fix_meterlimt= True):
+    def save(self,filename,hidelayers = (),targetlayer = None,fix_meterlimt= True):
         """convenience function, inserts layers and then calls
         wirte_svg to save"""
         if targetlayer:
             self.insert_figures(fflayername=targetlayer)
         else:
             self.insert_figures()
-        for l in hidelayers:
-            self.set_layer_visibility(l,False)
+        self._hide_layers(*hidelayers)
         self.write_svg(filename)
         from . import mpl_functions
         if fix_meterlimt:
             mpl_functions.fix_mpl_svg(filename)
+
+    def _hide_layers(self, *layer_names):
+        for l in layer_names:
+            self.set_layer_visibility(l, False)
 
     def clear_fflayer(self, fflayername):
         '''

--- a/figurefirst/svg_to_axes.py
+++ b/figurefirst/svg_to_axes.py
@@ -701,13 +701,19 @@ class PatchSpec(PathSpec):
 
 
 class FigureLayout(object):
-    """ autogenlayers - if True, figurefirst will automatically create targetlayers in the svg for each figure,
-    default: True make_mplfigures - if True, figurefirst will call self.make_mplfigures() during init dpi - default 300,
-    which is desired for print figures hide_layers - list of inkscape layer names you want to set to
-    invisible (e.g. your template layers) construct an object that specifies the figure layout fom the svg file layout_filename.
-    """
+    def __init__(self, layout_filename, autogenlayers=True,make_mplfigures = False, dpi=300, hide_layers=("Layer 1",)):
+        """An object which specifies the figure layout fom the svg file layout_filename.
 
-    def __init__(self, layout_filename, autogenlayers=True,make_mplfigures = False, dpi=300, hide_layers=['Layer 1']):
+        :param layout_filename:
+        :param autogenlayers: bool
+            If True, figurefirst will automatically create target layers in the svg for each figure. Default True.
+        :param make_mplfigures: bool
+            If True, figurefirst will call self.make_mplfigures() during instantiation. Default False.
+        :param dpi: float
+            Dots per inch. Default 300.
+        :param hide_layers: iterable of str
+            Names of inkscape layers you want to make invisible (e.g. your template layers). Default ("Layer 1",).
+        """
         self.dpi = dpi # should be 300 for print figures
         self.autogenlayers = autogenlayers
         self.layout_filename = os.path.join(layout_filename)
@@ -755,7 +761,7 @@ class FigureLayout(object):
         # for now
         #assert self.layout_user_sx == self.layout_user_sy
         if np.abs(self.layout_user_sx[0] - self.layout_user_sy[0]) > figurefirst_user_parameters.rounding_tolerance:
-            warnings.warn("""The the scaling of the user units in x and y are different and may result in unexpected
+            warn("""The the scaling of the user units in x and y are different and may result in unexpected
                             behavior. Make sure that the aspect ratio defined by the viewbox attribute of the root
                             SVG node is the same as that given by the document hight and width.""")
         if make_mplfigures:


### PR DESCRIPTION
See #48: it was an "I don't understand figurefirst" issue rather than a bug. This PR:

1. Adds some documentation to stop others getting stuck like me!
2. Fixes the "Basic usage" example which didn't actually work
3. Formats the FigureLayout docstring nicely
4. Replaces the default `hide_layers` list with a tuple, because [bad things can happen with mutable default arguments](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments).