### PR TITLE
[WIP] CI polish to target 0.0.7 release

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Tests
 
 on: [push]
 

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -17,13 +17,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: "Install dependencies"
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
-        pip install -r requirements.txt
-    - name: Install Tox
-      run: pip install tox
-    - name: Run Tox
+        pip install tox tox-gh-actions
+    - name: "Run tox targets for ${{ matrix.python-version }}"
       # Run tox using the version of Python in `PATH`
-      run: tox -e py
+      run: python -m tox

--- a/.github/workflows/security-check-workflow.yml
+++ b/.github/workflows/security-check-workflow.yml
@@ -1,0 +1,21 @@
+name: Security-check
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: "Install dependencies"
+      run: |
+        python -m pip install --upgrade pip
+        pip install bandit
+    - name: "Run security check using bandit"
+      run: bandit -r figurefirst

--- a/.github/workflows/security-check-workflow.yml
+++ b/.github/workflows/security-check-workflow.yml
@@ -9,13 +9,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - name: Security check - Bandit
+      uses: Joel-hanson/bandit-report-artifacts@V1
       with:
-        python-version: 3.8
-    - name: "Install dependencies"
-      run: |
-        python -m pip install --upgrade pip
-        pip install bandit
-    - name: "Run security check using bandit"
-      run: bandit -r figurefirst
+        python_version: 3.8
+        project_path: figurefirst
+        ignore_failure: true
+
+    - name: Security check report artifacts
+      uses: actions/upload-artifact@v1
+      # if: failure()
+      with:
+        name: Security report
+        path: output/security_report.txt
+
+    - name: "Flake8 warnings"
+      uses: TrueBrain/actions-flake8@master
+      with:
+        path: figurefirst
+        only_warn: 1

--- a/.github/workflows/security-check-workflow.yml
+++ b/.github/workflows/security-check-workflow.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ python-version }}
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
         python-version: 3.8

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/flyranch/figurefirst/workflows/Tests/badge.svg)
+![](https://github.com/flyranch/figurefirst/workflows/Tests/badge.svg?branch=master)
 ![](https://img.shields.io/pypi/v/figurefirst)
 ![](https://img.shields.io/github/license/flyranch/figurefirst)
 ![](https://img.shields.io/badge/code%20style-black-000000.svg)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+![](https://github.com/flyranch/figurefirst/workflows/Python%20package/badge.svg)
+![](https://img.shields.io/pypi/v/figurefirst)
+![](https://img.shields.io/github/license/flyranch/figurefirst)
+![](https://img.shields.io/badge/code%20style-black-000000.svg)
 # FigureFirst
 FigureFirst is a python 3.5+ library to decorate and parse SVG files so they can serve as layout documents for matplotlib figures. In principle FigureFirst works on python 2.7, but it is not officially supported. 
 * See our github page for readme and examples: http://flyranch.github.io/figurefirst/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/flyranch/figurefirst/workflows/Python%20package/badge.svg)
+![](https://github.com/flyranch/figurefirst/workflows/Tests/badge.svg)
 ![](https://img.shields.io/pypi/v/figurefirst)
 ![](https://img.shields.io/github/license/flyranch/figurefirst)
 ![](https://img.shields.io/badge/code%20style-black-000000.svg)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+flake8
+sphinx
+black

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(
         "dill",
         "backports.functools_lru_cache; python_version<'3.3'",
     ],
+    extras_require={
+        'dev': ['tox','sphinx','black'],
+        'docs': ['sphinx']},
     include_package_data=True,
     license="BSD",
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'dev': ['tox','sphinx','black'],
         'docs': ['sphinx']},
     include_package_data=True,
-    license="BSD",
+    license="MIT",
     entry_points={
         "console_scripts": [
             "figurefirst_ext=figurefirst_scripts.install_inkscape_ext:main"

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ python =
     3.5: py35,
     3.6: py36,
     3.7: py37,
-    3.8: py38, py38-black
+    3.8: py38, black
 
 [testenv]
 deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,21 @@
 [tox]
-envlist=py{35,36,37,38}
+envlist=py{35,36,37,38,py38-black}
 
 [gh-actions]
 python =
     3.5: py35,
     3.6: py36,
     3.7: py37,
-    3.8: py38,
+    3.8: py38, py38-black
 
 [testenv]
 deps = -rrequirements.txt
 commands =
     pip install .
     pytest -v
+
+[testenv:py38-black]
+deps =
+    black
+commands =
+    black --check --diff figurefirst

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
     pip install .
     pytest -v
 
-[testenv:py38-black]
+[testenv:black]
 deps =
     black
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,12 @@
 [tox]
-envlist=py{35,36,37}
+envlist=py{35,36,37,38}
+
+[gh-actions]
+python =
+    3.5: py35,
+    3.6: py36,
+    3.7: py37,
+    3.8: py38,
 
 [testenv]
 deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist=py{35,36,37,38,py38-black}
+envlist=py{35,36,37,38,38-black}
 
 [gh-actions]
 python =
     3.5: py35,
     3.6: py36,
     3.7: py37,
-    3.8: py38, black
+    3.8: py38, py38-black
 
 [testenv]
 deps = -rrequirements.txt
@@ -14,7 +14,7 @@ commands =
     pip install .
     pytest -v
 
-[testenv:black]
+[testenv:py38-black]
 deps =
     black
 commands =


### PR DESCRIPTION
* consolidated github action and .tox workflow steps closes #56 
* add another workflow to run black and flake8. At the moment these are set to always return a pass but we can read the error reports in the action output console [like this one](https://github.com/FlyRanch/figurefirst/runs/725755893?check_suite_focus=true) Perhaps we can set these as mandatory later.
*  Added some badges to report on the test results and pypi version.

Todo?: 
- [ ] Add build and publish to pypi workflow.
- [ ] Add workflow to build and publish docs