### PR TITLE
Fix write_svg method, open the file in binary mode

### DIFF
--- a/figurefirst/svg_to_axes.py
+++ b/figurefirst/svg_to_axes.py
@@ -1444,7 +1444,7 @@ class FigureLayout(object):
             self.output_xml.writexml(outfile, encoding="utf-8")
         except UnicodeEncodeError:
             outfile.close()
-            outfile = open(output_filename, "w")
+            outfile = open(output_filename, "wb")
             outfile.write(self.output_xml.toxml().encode("ascii", "xmlcharrefreplace"))
             outfile.close()
 


### PR DESCRIPTION
Fix issue #51: https://github.com/FlyRanch/figurefirst/issues/51

Need to open the svg file in binary mode so use 'wb' instead of 'w'. 

May also need to make this change in the extensions for version 1.0 & 0.x, but not tested yet.